### PR TITLE
Remove Classification, rework Priority filter and Advanced filter

### DIFF
--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -3201,8 +3201,9 @@
         async function applyStatusFilters() {
             try {
                 // Scan the directory on first use so the advanced filter can run
-                // without requiring a prior search.
-                if (!lastRoadmapFiles) {
+                // without requiring a prior search. `lastRoadmapFiles` is
+                // initialised to [] elsewhere, so check length too.
+                if (!lastRoadmapFiles || !lastRoadmapFiles.length) {
                     if (!selectedDirectory) {
                         showMessage('Please select a directory first', 'warning');
                         return;

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -3200,30 +3200,38 @@
          */
         function applyStatusFilters() {
             try {
-                // Re-filter the last search results with the new status filters
-                if (lastSearchStories && lastSearchStories.length > 0) {
-                    const filteredStories = applyAdditionalFilters(lastSearchStories, lastRoadmapFiles, {});
-                    
-                    // Get the current search parameters to determine which range to use
-                    const startDate = document.getElementById('startDateInput')?.value;
-                    const endDate = document.getElementById('endDateInput')?.value;
-                    const searchModeEl = document.getElementById('searchModeSelect');
-                    const searchMode = (searchModeEl && searchModeEl.value) ? searchModeEl.value : 'exact';
-                    
-                    // Create search range info if dates exist
-                    let searchRange = null;
-                    if (startDate || endDate) {
-                        searchRange = {
-                            startDate: startDate || 'N/A',
-                            endDate: endDate || 'N/A',
-                            mode: searchMode
-                        };
-                    }
-                    
-                    // Display the filtered results
-                    displaySearchResults(filteredStories, 'Filtered Results', searchRange);
-                    currentResults = filteredStories;
+                if (!lastRoadmapFiles) {
+                    showMessage('Run a search first so the filter has a dataset to work on', 'warning');
+                    return;
                 }
+
+                // Re-aggregate from the scanned files so the filter runs against the
+                // full dataset, not just the previous search's narrow result set.
+                // applyAdditionalFilters still respects any search inputs that are
+                // currently filled (IMO, priority, title, dates, etc.).
+                const allStories = IMOUtility.aggregateStoriesAcrossTeams(lastRoadmapFiles);
+                lastSearchStories = allStories.slice();
+                const filteredStories = applyAdditionalFilters(allStories, lastRoadmapFiles, {});
+
+                // Get the current search parameters to determine which range to use
+                const startDate = document.getElementById('startDateInput')?.value;
+                const endDate = document.getElementById('endDateInput')?.value;
+                const searchModeEl = document.getElementById('searchModeSelect');
+                const searchMode = (searchModeEl && searchModeEl.value) ? searchModeEl.value : 'exact';
+
+                // Create search range info if dates exist
+                let searchRange = null;
+                if (startDate || endDate) {
+                    searchRange = {
+                        startDate: startDate || 'N/A',
+                        endDate: endDate || 'N/A',
+                        mode: searchMode
+                    };
+                }
+
+                // Display the filtered results
+                displaySearchResults(filteredStories, 'Filtered Results', searchRange);
+                currentResults = filteredStories;
             } catch (e) {
                 console.error('Error applying status filters:', e);
                 showMessage('Error applying filters', 'error');

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -184,7 +184,7 @@
             width: 300px;
         }
         
-        .search-input.classification-select {
+        .search-input.dropdown-select {
             flex: none;
             width: 150px;
         }
@@ -696,7 +696,7 @@
                 <div class="search-section">
                     <h3 class="search-section-title">🎯 Priority Search</h3>
                     <div class="search-input-group">
-                        <select class="search-input classification-select" id="prioritySelect" onchange="updateSearchButtonStates()">
+                        <select class="search-input dropdown-select" id="prioritySelect" onchange="updateSearchButtonStates()">
                             <option value="">Any Priority</option>
                             <option value="High">High</option>
                             <option value="Medium">Medium</option>
@@ -712,17 +712,11 @@
                 <div class="search-section">
                     <h3 class="search-section-title">🔍 IMO/Project ID Search</h3>
                     <div class="search-input-group">
-                            <input type="text" 
-                               class="search-input imo-input" 
-                                   id="searchInput" 
-                               placeholder="Enter IMO/Project ID" 
+                            <input type="text"
+                               class="search-input imo-input"
+                                   id="searchInput"
+                               placeholder="Enter IMO/Project ID"
                                    onkeypress="handleSearchKeyPress(event)">
-                        <select class="search-input classification-select" id="imoClassificationSelect">
-                            <option value="">Classification</option>
-                            <option value="Payments">Payments</option>
-                            <option value="Banking">Banking</option>
-                            <option value="Other">Other</option>
-                        </select>
                         <button class="search-button" id="imoSearchBtn" onclick="performIMOSearch()" disabled>
                             🔍 Search
                             </button>
@@ -944,10 +938,6 @@
                         <div style="flex: 1;">
                             <label>IMO <span style="font-style: italic; color: #888;">(optional)</span>:</label>
                             <div class="readonly-field" id="viewIMO"></div>
-                        </div>
-                        <div style="flex: 1;">
-                            <label>Classification:</label>
-                            <div class="readonly-field" id="viewIMOClassification"></div>
                         </div>
                         <div style="flex: 1;">
                             <label>Priority:</label>
@@ -1762,13 +1752,6 @@
             }
             document.getElementById('viewIMO').textContent = imoText || 'None';
             
-            // Handle IMO Classification
-            let imoClassificationText = '';
-            if (storyData.imoClassification) {
-                imoClassificationText = String(storyData.imoClassification);
-            }
-            document.getElementById('viewIMOClassification').textContent = imoClassificationText || 'None';
-
             // Handle Priority
             let priorityText = '';
             if (storyData.priority) {
@@ -2705,7 +2688,6 @@
             // Clear search inputs
             document.getElementById('searchInput').value = '';
             document.getElementById('titleSearchInput').value = '';
-            document.getElementById('imoClassificationSelect').value = '';
             const priorityEl = document.getElementById('prioritySelect');
             if (priorityEl) priorityEl.value = '';
             const directorEl = document.getElementById('directorSearchInput');
@@ -2767,7 +2749,7 @@
         // Apply additional filters based on other filled inputs (AND semantics)
         function applyAdditionalFilters(stories, roadmapFiles, options = {}) {
             let result = Array.isArray(stories) ? stories.slice() : [];
-            const opts = Object.assign({ skipDirector: false, skipIMO: false, skipClassification: false, skipPriority: false, skipTitle: false, skipDate: false, skipStatus: false, skipProductRoadmap: false }, options);
+            const opts = Object.assign({ skipDirector: false, skipIMO: false, skipPriority: false, skipTitle: false, skipDate: false, skipStatus: false, skipProductRoadmap: false }, options);
 
             try {
                 // Director/VP filter (team-level)
@@ -2782,15 +2764,6 @@
                 const imoQuery = document.getElementById('searchInput')?.value.trim();
                 if (!opts.skipIMO && imoQuery) {
                     result = IMOUtility.filterStoriesByIMO(result, imoQuery);
-                }
-
-                // Classification filter
-                const classificationQuery = document.getElementById('imoClassificationSelect')?.value;
-                if (!opts.skipClassification && classificationQuery) {
-                    result = result.filter(story => {
-                        const storyClassification = (story.imoClassification || '').toLowerCase();
-                        return storyClassification === classificationQuery.toLowerCase();
-                    });
                 }
 
                 // Priority filter
@@ -2928,12 +2901,6 @@
             processedExpr = processedExpr.replace(/IMO="([^"]+)"/gi, (match, value) => {
                 const imo = (story.imo || '').toLowerCase();
                 return imo.includes(value.toLowerCase()) ? 'TRUE' : 'FALSE';
-            });
-            
-            // IMOCLASS="class" - matches IMO classification
-            processedExpr = processedExpr.replace(/IMOCLASS="([^"]+)"/gi, (match, value) => {
-                const imoClass = (story.imoClassification || '').toLowerCase();
-                return imoClass.includes(value.toLowerCase()) ? 'TRUE' : 'FALSE';
             });
             
             // TEAM="name" - matches team name
@@ -3165,7 +3132,6 @@
                     <div style="margin-bottom: 15px;">
                         <strong>FIELD FILTERS (partial match):</strong><br>
                         <code>IMO="0043"</code> - IMO number<br>
-                        <code>IMOCLASS="Payments"</code> - Classification<br>
                         <code>TEAM="Terminal"</code> - Team name<br>
                         <code>EPIC="Core"</code> - Epic name<br>
                         <code>TITLE="migration"</code> - Story title<br>

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -825,6 +825,7 @@
                             <div style="font-size: 10px; color: #888; margin-top: 5px;">
                                 Use: <code>&&</code> (AND), <code>||</code> (OR), <code>!</code> (NOT), <code>( )</code> (grouping)<br>
                                 Status names: Done, Cancelled, Timeline, New, AtRisk, Proposed, Info, TransferredIn, TransferredOut<br>
+                                Field presence: IMO, Priority (use <code>!</code> for empty) &nbsp;&nbsp; Priority values: High, Medium, Low<br>
                                 Expression overrides checkboxes if provided.
                             </div>
                         </div>
@@ -2899,6 +2900,12 @@
                 const imo = (story.imo || '').toLowerCase();
                 return imo.includes(value.toLowerCase()) ? 'TRUE' : 'FALSE';
             });
+
+            // PRIORITY="value" - matches priority value (exact, case-insensitive)
+            processedExpr = processedExpr.replace(/PRIORITY="([^"]+)"/gi, (match, value) => {
+                const priority = (story.priority || '').toLowerCase();
+                return priority === value.toLowerCase() ? 'TRUE' : 'FALSE';
+            });
             
             // TEAM="name" - matches team name
             processedExpr = processedExpr.replace(/TEAM="([^"]+)"/gi, (match, value) => {
@@ -2994,6 +3001,9 @@
                 }
                 
                 // Handle status names
+                const storyPriority = (story.priority || '').toLowerCase();
+                const hasIMO = Boolean((story.imo || '').toString().trim());
+                const hasPriority = storyPriority.length > 0;
                 const statusMap = {
                     'Done': story.isDone,
                     'Cancelled': story.isCancelled,
@@ -3004,6 +3014,13 @@
                     'Info': story.isInfo,
                     'TransferredIn': story.isTransferredIn,
                     'TransferredOut': story.isTransferredOut,
+                    // Field presence tokens
+                    'IMO': hasIMO,
+                    'Priority': hasPriority,
+                    // Priority value tokens (case-insensitive)
+                    'High': storyPriority === 'high',
+                    'Medium': storyPriority === 'medium',
+                    'Low': storyPriority === 'low',
                     // Special tokens for pre-processed LEADERSHIP expressions
                     'TRUE': true,
                     'FALSE': false
@@ -3127,8 +3144,18 @@
                         <code>Proposed</code> <code>Info</code> <code>TransferredIn</code> <code>TransferredOut</code>
                     </div>
                     <div style="margin-bottom: 15px;">
-                        <strong>FIELD FILTERS (partial match):</strong><br>
-                        <code>IMO="0043"</code> - IMO number<br>
+                        <strong>FIELD PRESENCE:</strong><br>
+                        <code>IMO</code> - IMO is filled &nbsp;&nbsp; <code>!IMO</code> - IMO is empty<br>
+                        <code>Priority</code> - Priority is set &nbsp;&nbsp; <code>!Priority</code> - Priority is empty
+                    </div>
+                    <div style="margin-bottom: 15px;">
+                        <strong>PRIORITY VALUES:</strong><br>
+                        <code>High</code> <code>Medium</code> <code>Low</code> (case-insensitive)
+                    </div>
+                    <div style="margin-bottom: 15px;">
+                        <strong>FIELD FILTERS (partial match unless noted):</strong><br>
+                        <code>IMO="0043"</code> - IMO number (partial)<br>
+                        <code>PRIORITY="High"</code> - Priority (exact)<br>
                         <code>TEAM="Terminal"</code> - Team name<br>
                         <code>EPIC="Core"</code> - Epic name<br>
                         <code>TITLE="migration"</code> - Story title<br>
@@ -3142,7 +3169,10 @@
                         <code>TEAM="Terminal" && Done</code><br>
                         <code>IMO="0043" || IMO="0044"</code><br>
                         <code>(TEAM="A" || TEAM="B") && !Cancelled</code><br>
-                        <code>COUNTRY="UK" && LEADERSHIP="John"</code>
+                        <code>COUNTRY="UK" && LEADERSHIP="John"</code><br>
+                        <code>!IMO</code> - stories without IMO<br>
+                        <code>High && !Done</code> - High priority, not done<br>
+                        <code>!IMO && Priority</code> - no IMO but has priority
                     </div>
                 </div>
             `;

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -2901,6 +2901,14 @@
                 return imo.includes(value.toLowerCase()) ? 'TRUE' : 'FALSE';
             });
 
+            // IMO<chars> (no quotes) - shorthand keyword search on the IMO field.
+            // Bare `IMO` (no suffix) is handled later as a presence token, so the
+            // suffix regex requires at least one non-operator character.
+            processedExpr = processedExpr.replace(/\bIMO([^\s!&|()"]+)/gi, (match, value) => {
+                const imo = (story.imo || '').toLowerCase();
+                return imo.includes(value.toLowerCase()) ? 'TRUE' : 'FALSE';
+            });
+
             // PRIORITY="value" - matches priority value (exact, case-insensitive)
             processedExpr = processedExpr.replace(/PRIORITY="([^"]+)"/gi, (match, value) => {
                 const priority = (story.priority || '').toLowerCase();

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -3198,11 +3198,22 @@
         /**
          * Apply status filters to current search results
          */
-        function applyStatusFilters() {
+        async function applyStatusFilters() {
             try {
+                // Scan the directory on first use so the advanced filter can run
+                // without requiring a prior search.
                 if (!lastRoadmapFiles) {
-                    showMessage('Run a search first so the filter has a dataset to work on', 'warning');
-                    return;
+                    if (!selectedDirectory) {
+                        showMessage('Please select a directory first', 'warning');
+                        return;
+                    }
+                    showLoadingState('Loading stories...');
+                    const roadmapFiles = await IMOUtility.scanRoadmapDirectory(selectedDirectory);
+                    if (!roadmapFiles.length) {
+                        showMessage('No roadmap JSON files found in the selected directory', 'warning');
+                        return;
+                    }
+                    lastRoadmapFiles = roadmapFiles;
                 }
 
                 // Re-aggregate from the scanned files so the filter runs against the
@@ -3229,12 +3240,19 @@
                     };
                 }
 
+                if (!filteredStories.length) {
+                    showMessage('No stories match the current filters', 'info');
+                    currentResults = [];
+                    return;
+                }
+
                 // Display the filtered results
                 displaySearchResults(filteredStories, 'Filtered Results', searchRange);
                 currentResults = filteredStories;
+                document.getElementById('searchStatsBtn').disabled = false;
             } catch (e) {
                 console.error('Error applying status filters:', e);
-                showMessage('Error applying filters', 'error');
+                showMessage('Error applying filters: ' + e.message, 'error');
             }
         }
 

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -3088,8 +3088,8 @@
                 showAdvancedFilterHelp();
                 return;
             }
-            // Ctrl+Enter or Cmd+Enter to apply filter
-            if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+            // Enter (plain or with Ctrl/Cmd) applies the filter
+            if (event.key === 'Enter') {
                 event.preventDefault();
                 applyStatusFilters();
             }

--- a/web/imo-search.html
+++ b/web/imo-search.html
@@ -692,22 +692,6 @@
                     </div>
                 </div>
 
-                <!-- Priority Search -->
-                <div class="search-section">
-                    <h3 class="search-section-title">🎯 Priority Search</h3>
-                    <div class="search-input-group">
-                        <select class="search-input dropdown-select" id="prioritySelect" onchange="updateSearchButtonStates()">
-                            <option value="">Any Priority</option>
-                            <option value="High">High</option>
-                            <option value="Medium">Medium</option>
-                            <option value="Low">Low</option>
-                        </select>
-                        <button class="search-button" id="prioritySearchBtn" onclick="performPrioritySearch()" disabled>
-                            🎯 Search Priority
-                        </button>
-                    </div>
-                </div>
-
                 <!-- IMO Search -->
                 <div class="search-section">
                     <h3 class="search-section-title">🔍 IMO/Project ID Search</h3>
@@ -717,6 +701,12 @@
                                    id="searchInput"
                                placeholder="Enter IMO/Project ID"
                                    onkeypress="handleSearchKeyPress(event)">
+                        <select class="search-input dropdown-select" id="prioritySelect" onchange="updateSearchButtonStates()">
+                            <option value="">Any Priority</option>
+                            <option value="High">High</option>
+                            <option value="Medium">Medium</option>
+                            <option value="Low">Low</option>
+                        </select>
                         <button class="search-button" id="imoSearchBtn" onclick="performIMOSearch()" disabled>
                             🔍 Search
                             </button>
@@ -2362,54 +2352,61 @@
                     alert('Please select a directory first');
                         return;
                     }
-                
+
                 const searchQuery = document.getElementById('searchInput').value.trim();
-                if (!searchQuery) {
-                    alert('Please enter a search query');
+                const priorityValue = document.getElementById('prioritySelect')?.value || '';
+                if (!searchQuery && !priorityValue) {
+                    alert('Please enter an IMO/Project ID or select a priority');
                         return;
                     }
-                
+
+                const searchLabel = searchQuery
+                    ? `"${searchQuery}"${priorityValue ? ` + Priority: ${priorityValue}` : ''}`
+                    : `Priority: ${priorityValue}`;
+
                 // Show loading state
-                showLoadingState(`Searching for "${searchQuery}"...`);
-                
+                showLoadingState(`Searching for ${searchLabel}...`);
+
                 // Scan directory for roadmap files
                 const roadmapFiles = await IMOUtility.scanRoadmapDirectory(selectedDirectory);
-                
+
                 if (roadmapFiles.length === 0) {
                     showMessage('No roadmap JSON files found in the selected directory', 'warning');
                     return;
                 }
-                
+
                 // Extract and search stories
                 const allStories = IMOUtility.aggregateStoriesAcrossTeams(roadmapFiles);
-                
-                // Direct IMO/Project ID search (no query parsing)
-                let matchingStories = IMOUtility.filterStoriesByIMO(allStories, searchQuery);
-                
+
+                // Narrow by IMO if provided, otherwise start with all stories
+                let matchingStories = searchQuery
+                    ? IMOUtility.filterStoriesByIMO(allStories, searchQuery)
+                    : allStories.slice();
+
                 // Store base search results before filtering for potential re-filtering
                 lastSearchStories = matchingStories.slice();
                 lastRoadmapFiles = roadmapFiles;
-                
+
                 matchingStories = applyAdditionalFilters(matchingStories, roadmapFiles, { skipIMO: true });
-                
+
                 if (matchingStories.length === 0) {
-                    showMessage(`No stories found for "${searchQuery}"`, 'info');
+                    showMessage(`No stories found for ${searchLabel}`, 'info');
                     return;
                 }
-                
+
                 // Store results and display
                 currentResults = matchingStories;
-                displaySearchResults(matchingStories, searchQuery);
-                
+                displaySearchResults(matchingStories, searchLabel);
+
                 // Enable stats button
                 document.getElementById('searchStatsBtn').disabled = false;
-                
+
             } catch (error) {
-                
+
                 showMessage('Search error: ' + error.message, 'error');
             }
         }
-        
+
         // Temporary variable for search results force text below (one-time action)
         let searchTempForceTextBelow = false;
         let lastSearchQuery = null;
@@ -3235,7 +3232,6 @@
             const dateRangeSearchBtn = document.getElementById('dateRangeSearchBtn');
             const directorVPIdSearchBtn = document.getElementById('directorVPIdSearchBtn');
             const countryFlagSearchBtn = document.getElementById('countryFlagSearchBtn');
-            const prioritySearchBtn = document.getElementById('prioritySearchBtn');
 
             const hasDirectory = !!selectedDirectory;
             const hasImoInput = document.getElementById('searchInput').value.trim().length > 0;
@@ -3247,12 +3243,11 @@
             const hasEndDate = document.getElementById('endDateInput').value.length > 0;
             const hasAnyDate = hasStartDate || hasEndDate;
 
-            imoSearchBtn.disabled = !hasDirectory || !hasImoInput;
+            imoSearchBtn.disabled = !hasDirectory || (!hasImoInput && !hasPriorityInput);
             titleSearchBtn.disabled = !hasDirectory || !hasTitleInput;
             dateRangeSearchBtn.disabled = !hasDirectory || !hasAnyDate;
             directorVPIdSearchBtn.disabled = !hasDirectory || !hasDirectorVPIdInput;
             countryFlagSearchBtn.disabled = !hasDirectory || !hasCountryFlagInput;
-            if (prioritySearchBtn) prioritySearchBtn.disabled = !hasDirectory || !hasPriorityInput;
         }
 
         /**
@@ -3600,56 +3595,6 @@
             document.getElementById('searchFlagUK').checked = false;
             document.getElementById('searchFlagDE').checked = false;
             document.getElementById('searchFlagFR').checked = false;
-        }
-
-        async function performPrioritySearch() {
-            try {
-                if (!selectedDirectory) {
-                    alert('Please select a directory first');
-                    return;
-                }
-
-                const priorityValue = document.getElementById('prioritySelect')?.value;
-                if (!priorityValue) {
-                    alert('Please select a priority');
-                    return;
-                }
-
-                showLoadingState(`Searching stories with priority: ${priorityValue}...`);
-
-                const roadmapFiles = await IMOUtility.scanRoadmapDirectory(selectedDirectory);
-                if (roadmapFiles.length === 0) {
-                    showMessage('No roadmap JSON files found in the selected directory', 'warning');
-                    return;
-                }
-
-                const allStories = IMOUtility.aggregateStoriesAcrossTeams(roadmapFiles);
-                const matchingStories = allStories.filter(story =>
-                    (story.priority || '').toLowerCase() === priorityValue.toLowerCase()
-                );
-
-                if (!matchingStories.length) {
-                    showMessage(`No stories found with priority: ${priorityValue}`, 'info');
-                    return;
-                }
-
-                lastSearchStories = matchingStories.slice();
-                lastRoadmapFiles = roadmapFiles;
-
-                const filteredStories = applyAdditionalFilters(matchingStories, roadmapFiles, { skipPriority: true });
-
-                if (!filteredStories.length) {
-                    showMessage(`No stories found for priority: ${priorityValue}`, 'info');
-                    return;
-                }
-
-                currentResults = filteredStories;
-                displaySearchResults(filteredStories, `Priority: ${priorityValue}`);
-
-                document.getElementById('searchStatsBtn').disabled = false;
-            } catch (error) {
-                showMessage('Search error: ' + error.message, 'error');
-            }
         }
 
         async function performCountryFlagSearch() {

--- a/web/roadmap-builder.html
+++ b/web/roadmap-builder.html
@@ -25,7 +25,7 @@
     
     <!-- Layout Toggle Styles -->
     <style>
-        /* Disabled select styling for IMO Classification */
+        /* Disabled select styling */
         select:disabled {
             background-color: #e9ecef;
             color: #6c757d;
@@ -1069,16 +1069,7 @@
                     <div class="form-group" style="display: flex; gap: 15px; align-items: flex-end;">
                         <div style="flex: 1;">
                             <label for="editIMO">IMO/Project ID <span style="font-style: italic; color: #888;">(optional)</span>:</label>
-                            <input type="text" id="editIMO" name="imo" placeholder="0001" oninput="toggleEditIMOClassification()">
-                        </div>
-                        <div style="flex: 1;">
-                            <label for="editIMOClassification">Classification:</label>
-                            <select id="editIMOClassification" name="imoClassification" style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px;" disabled>
-                                <option value="">Select...</option>
-                                <option value="Payments">Payments</option>
-                                <option value="Banking">Banking</option>
-                                <option value="Other">Other</option>
-                            </select>
+                            <input type="text" id="editIMO" name="imo" placeholder="0001">
                         </div>
                         <div style="flex: 1;">
                             <label for="editPriority">Priority <span style="font-style: italic; color: #888;">(optional)</span>:</label>
@@ -2762,16 +2753,7 @@
                     <div class="form-group" style="display: flex; gap: 15px; align-items: flex-end;">
                         <div style="flex: 1;">
                             <label for="story-imo-${storyId}">IMO/Project ID <span style="font-style: italic; color: #888;">(optional)</span>:</label>
-                            <input type="text" id="story-imo-${storyId}" placeholder="0001" oninput="toggleStoryIMOClassification('${storyId}')">
-                        </div>
-                        <div style="flex: 1;">
-                            <label for="story-imo-classification-${storyId}">Classification:</label>
-                            <select id="story-imo-classification-${storyId}" style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px;" disabled>
-                                <option value="">Select...</option>
-                                <option value="Payments">Payments</option>
-                                <option value="Banking">Banking</option>
-                                <option value="Other">Other</option>
-                            </select>
+                            <input type="text" id="story-imo-${storyId}" placeholder="0001">
                         </div>
                         <div style="flex: 1;">
                             <label for="story-priority-${storyId}">Priority <span style="font-style: italic; color: #888;">(optional)</span>:</label>
@@ -3013,7 +2995,6 @@
                 `story-bullets-${storyId}`,
                 `story-director-vp-id-${storyId}`,
                 `story-imo-${storyId}`,
-                `story-imo-classification-${storyId}`,
                 `story-priority-${storyId}`,
                 `done-date-${storyId}`,
                 `done-notes-${storyId}`,
@@ -4819,13 +4800,6 @@
                 story.imo = imo;
             }
             
-            // Handle IMO Classification
-            const imoClassificationEl = document.getElementById(`story-imo-classification-${storyId}`);
-            const imoClassification = imoClassificationEl ? imoClassificationEl.value : '';
-            if (imoClassification) {
-                story.imoClassification = imoClassification;
-            }
-
             // Handle Priority
             const priorityEl = document.getElementById(`story-priority-${storyId}`);
             const priority = priorityEl ? priorityEl.value : '';
@@ -6704,20 +6678,11 @@
                     imoEl.value = story.imo || '';
                 }
                 
-                // Load IMO Classification field with error checking
-                const imoClassificationEl = document.getElementById(`story-imo-classification-${storyId}`);
-                if (imoClassificationEl) {
-                    imoClassificationEl.value = story.imoClassification || '';
-                }
-
                 // Load Priority field with error checking
                 const priorityEl = document.getElementById(`story-priority-${storyId}`);
                 if (priorityEl) {
                     priorityEl.value = story.priority || '';
                 }
-
-                // Enable/disable classification based on IMO value
-                toggleStoryIMOClassification(storyId);
                 
                 // Load Comments field
                 const commentsEl = document.getElementById(`story-comments-${storyId}`);
@@ -7286,12 +7251,8 @@
             document.getElementById('editBullets').value = foundStory.bullets || '';
             document.getElementById('editDirectorVPId').value = foundStory.directorVPId || '';
             document.getElementById('editIMO').value = foundStory.imo || '';
-            document.getElementById('editIMOClassification').value = foundStory.imoClassification || '';
             document.getElementById('editPriority').value = foundStory.priority || '';
             document.getElementById('editComments').value = foundStory.comments || '';
-            
-            // Enable/disable classification based on IMO value
-            toggleEditIMOClassification();
             
             // Load Country Flags (Global is checked by default if no flags are saved)
             const flags = foundStory.countryFlags || [];
@@ -7776,21 +7737,6 @@
         }
 
         /**
-         * Toggle the IMO Classification dropdown in the edit modal based on IMO input
-         */
-        function toggleEditIMOClassification() {
-            const imoInput = document.getElementById('editIMO');
-            const classificationSelect = document.getElementById('editIMOClassification');
-            if (imoInput && classificationSelect) {
-                const hasIMO = imoInput.value.trim().length > 0;
-                classificationSelect.disabled = !hasIMO;
-                if (!hasIMO) {
-                    classificationSelect.value = '';
-                }
-            }
-        }
-
-        /**
          * Clear Global flag in edit modal if any individual country is selected
          */
         function clearEditGlobalIfCountrySelected() {
@@ -7840,21 +7786,6 @@
                     const el = document.getElementById(`story-flag-${country}-${storyId}`);
                     if (el) el.checked = false;
                 });
-            }
-        }
-
-        /**
-         * Toggle the IMO Classification dropdown for a story form based on IMO input
-         */
-        function toggleStoryIMOClassification(storyId) {
-            const imoInput = document.getElementById(`story-imo-${storyId}`);
-            const classificationSelect = document.getElementById(`story-imo-classification-${storyId}`);
-            if (imoInput && classificationSelect) {
-                const hasIMO = imoInput.value.trim().length > 0;
-                classificationSelect.disabled = !hasIMO;
-                if (!hasIMO) {
-                    classificationSelect.value = '';
-                }
             }
         }
 
@@ -8255,7 +8186,6 @@
                             imo: imoEl ? imoEl.value : '',
                             priority: document.getElementById(`btl-priority-${storyId}`)?.value || '',
                             comments: commentsEl ? commentsEl.value : '',
-                            imoClassification: '', // BTL stories use modal classification
                             isDone: false, // BTL stories don't have status flags
                             isCancelled: false,
                             isAtRisk: false,
@@ -8318,8 +8248,7 @@
                     const bulletsEl = document.getElementById(`story-bullets-${storyId}`);
                     const directorVPIdEl = document.getElementById(`story-director-vp-id-${storyId}`);
                     const imoEl = document.getElementById(`story-imo-${storyId}`);
-                    const imoClassificationEl = document.getElementById(`story-imo-classification-${storyId}`);
-                    
+
                     const doneEl = document.getElementById(`story-done-${storyId}`);
                     const cancelledEl = document.getElementById(`story-cancelled-${storyId}`);
                     const atRiskEl = document.getElementById(`story-atrisk-${storyId}`);
@@ -8411,7 +8340,6 @@
                         bullets: bulletsEl ? bulletsEl.value : '',
                         directorVPId: directorVPIdEl ? directorVPIdEl.value : '',
                         imo: imoEl ? imoEl.value : '',
-                        imoClassification: imoClassificationEl ? imoClassificationEl.value : '',
                         priority: document.getElementById(`story-priority-${storyId}`)?.value || '',
                         comments: commentsEl ? commentsEl.value : '',
                         countryFlags: storyCountryFlags.length > 0 ? storyCountryFlags : undefined,
@@ -8458,16 +8386,7 @@
                 alert('No story selected for editing.');
                 return;
             }
-            
-            // Validate IMO classification is selected when IMO number is present
-            const imoValue = document.getElementById('editIMO').value.trim();
-            const imoClassification = document.getElementById('editIMOClassification').value;
-            if (imoValue && !imoClassification) {
-                alert('Please select a classification when an IMO/Project ID is provided.');
-                document.getElementById('editIMOClassification').focus();
-                return;
-            }
-            
+
             try{
                 // Find the story in the form
                 const foundStory = findStoryInForm(currentEditingStory.epicName, currentEditingStory.storyTitle, currentEditingStory.storyIndex);
@@ -8580,10 +8499,6 @@
                 if (bulletsEl) bulletsEl.value = document.getElementById('editBullets').value;
                 if (directorVPIdEl) directorVPIdEl.value = document.getElementById('editDirectorVPId').value;
                 if (imoEl) imoEl.value = document.getElementById('editIMO').value;
-                
-                // Update IMO Classification
-                const imoClassificationEl = document.getElementById(`story-imo-classification-${storyId}`);
-                if (imoClassificationEl) imoClassificationEl.value = document.getElementById('editIMOClassification').value;
 
                 // Update Priority
                 const priorityEl = document.getElementById(`story-priority-${storyId}`);

--- a/web/utilities/imo-view-generator.js
+++ b/web/utilities/imo-view-generator.js
@@ -1034,6 +1034,7 @@ class IMOViewGenerator {
                 endMonth: normalizedEndDate.monthStr,
                 bullets: processedBullets,
                 imo: String(story.imo || ''),
+                priority: String(story.priority || ''),
                 isDone: Boolean(story.isDone),
                 isCancelled: Boolean(story.isCancelled),
                 isAtRisk: Boolean(story.isAtRisk),


### PR DESCRIPTION
## Summary
- Removes the IMO Classification field from the Edit modal, story form, and Search (UI + advanced-filter IMOCLASS="..." keyword)
- Moves the Priority filter next to the IMO input; one Search button now searches by IMO, priority, or both
- Propagates `priority` through the cross-team transform so the colored tag shows on search results, matching the main roadmap
- Advanced filter now supports:
  - `IMO` / `!IMO` — presence / absence of the IMO field
  - `Priority` / `!Priority` — presence / absence of a priority
  - `High`, `Medium`, `Low` — match priority value (case-insensitive)
  - `PRIORITY="High"` — exact field filter
  - `IMO<value>` / `!IMO<value>` — shorthand for `IMO="<value>"`
- Advanced filter works as the first action after selecting a directory (auto-scans), re-aggregates against the full dataset so `!IMO` returns results, and applies on plain Enter

## Data compatibility
Existing `imoClassification` values in saved roadmap JSONs are ignored and dropped on the next save.

## Test plan
- [ ] Edit modal/story form no longer show Classification
- [ ] Priority dropdown sits between IMO input and Search button
- [ ] Search by IMO, by priority, or both
- [ ] Priority tag visible on search result roadmap
- [ ] Select directory, type `!IMO` in advanced filter, press Enter → all stories without IMO appear
- [ ] `High && !Done` works; `IMO0043` narrows by IMO
- [ ] Clear all resets priority and advanced filter