### PR TITLE
Fix debounce

### DIFF
--- a/web/roadmap-builder.html
+++ b/web/roadmap-builder.html
@@ -7773,6 +7773,7 @@
                 const globalEl = document.getElementById(`story-flag-global-${storyId}`);
                 if (globalEl) globalEl.checked = false;
             }
+            debouncedGeneratePreview();
         }
 
         /**
@@ -7787,6 +7788,7 @@
                     if (el) el.checked = false;
                 });
             }
+            debouncedGeneratePreview();
         }
 
         function toggleEditTimelineChanges() {


### PR DESCRIPTION
The country flag checkboxes in the main story form have onchange handlers that only toggle Global vs country exclusivity - they never trigger a preview re-render.