### PR TITLE
Add inline story editing and fix story click handlers in cross-team s…

### DIFF
--- a/web/roadmap-generator.js
+++ b/web/roadmap-generator.js
@@ -848,9 +848,9 @@ export class RoadmapGenerator {
         return `
             <div class="story-item${cancelledClass}${transferredClass}${proposedClass}${continuesClass}${zoomClass}${positionClass}"
              style="--start: ${startGrid}; --end: ${endGrid};"
-             data-epic-name="${this.formatText(epicName)}"
-             data-epic-id="${this.formatText(epicId)}"
-             data-story-title="${this.formatText(story.title)}"
+             data-epic-name="${(epicName || '').replace(/"/g, '&quot;')}"
+             data-epic-id="${(epicId || '').replace(/"/g, '&quot;')}"
+             data-story-title="${(story.title || '').replace(/"/g, '&quot;')}"
              data-story-index="${storyIndex}"
              data-story-id="${storyId}"
              data-json-story-id="${this.formatText(story.storyId || '')}">
@@ -1238,7 +1238,7 @@ export class RoadmapGenerator {
         <div class="story-track">
             <div class="ktlo-story${zoomClass}" 
                  data-epic-name="KTLO" 
-                 data-story-title="${this.formatText(ktloData.story.title)}" 
+                 data-story-title="${(ktloData.story.title || '').replace(/"/g, '&quot;')}" 
                  data-story-index="0"
                  data-story-id="">
                 ${editIconHTML}

--- a/web/views/imo-search/imo-search.css
+++ b/web/views/imo-search/imo-search.css
@@ -884,3 +884,80 @@
                 border-top-color: var(--surface-2);
             }
         }
+
+        /* ── Story edit mode ── */
+        .modal-header.edit-mode-header {
+            background-color: #fff8e1;
+            border-bottom-color: #f59e0b;
+        }
+        .modal-header.edit-mode-header h3::after {
+            content: ' — Editing';
+            font-size: 13px;
+            font-weight: 400;
+            color: #b45309;
+        }
+        .editable-field {
+            background-color: #fff;
+            border: 1px solid #f59e0b !important;
+            border-radius: 4px;
+            padding: 8px 12px;
+            min-height: 20px;
+            font-size: 14px;
+            line-height: 1.4;
+            color: #333;
+            outline: none;
+            cursor: text;
+        }
+        .editable-field:focus {
+            border-color: #d97706 !important;
+            box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+        }
+        .editable-bullets-textarea {
+            width: 100%;
+            min-height: 80px;
+            font-family: inherit;
+            font-size: 14px;
+            line-height: 1.4;
+            color: #333;
+            background-color: #fff;
+            border: 1px solid #f59e0b;
+            border-radius: 4px;
+            padding: 8px 12px;
+            box-sizing: border-box;
+            resize: vertical;
+        }
+        .editable-bullets-textarea:focus {
+            outline: none;
+            border-color: #d97706;
+            box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+        }
+        .edit-mode-hint {
+            font-size: 12px;
+            color: #b45309;
+            margin-bottom: 12px;
+            padding: 6px 10px;
+            background: #fff8e1;
+            border-radius: 4px;
+            border: 1px solid #fde68a;
+        }
+        @media (prefers-color-scheme: dark) {
+            .modal-header.edit-mode-header {
+                background-color: #2d2000;
+                border-bottom-color: #d97706;
+            }
+            .editable-field {
+                background-color: var(--surface-1);
+                color: var(--text-default);
+                border-color: #d97706 !important;
+            }
+            .editable-bullets-textarea {
+                background-color: var(--surface-1);
+                color: var(--text-default);
+                border-color: #d97706;
+            }
+            .edit-mode-hint {
+                background: #2d2000;
+                border-color: #78350f;
+                color: #fbbf24;
+            }
+        }

--- a/web/views/imo-search/imo-search.html
+++ b/web/views/imo-search/imo-search.html
@@ -430,7 +430,10 @@
                 </form>
             </div>
             <div class="modal-footer">
-                <button type="button" class="secondary" onclick="closeStoryDetailsModal()">Close</button>
+                <button type="button" id="storyEditBtn" class="primary" onclick="enterStoryEditMode()" style="display: none;">Edit</button>
+                <button type="button" id="storySaveBtn" class="primary" onclick="saveStoryChanges()" style="display: none;">Save Changes</button>
+                <button type="button" id="storyDiscardBtn" class="secondary" onclick="discardStoryEdits()" style="display: none;">Discard</button>
+                <button type="button" id="storyCloseBtn" class="secondary" onclick="closeStoryDetailsModal()">Close</button>
             </div>
         </div>
     </div>

--- a/web/views/imo-search/imo-search.js
+++ b/web/views/imo-search/imo-search.js
@@ -1110,15 +1110,16 @@ export function init(_root) {
         function addStoryClickHandlers(storiesData) {
             // Find all story items in the rendered roadmap
             const storyItems = document.querySelectorAll('.story-item, .ktlo-story');
-            
+
             storyItems.forEach((storyElement, index) => {
                 // Extract story identification from data attributes
                 const epicName = storyElement.dataset.epicName;
                 const storyTitle = storyElement.dataset.storyTitle;
                 const storyIndex = storyElement.dataset.storyIndex;
-                
+                const storyId = storyElement.dataset.jsonStoryId;
+
                 // Find matching story data
-                const storyData = findStoryData(storiesData, epicName, storyTitle, storyIndex);
+                const storyData = findStoryData(storiesData, epicName, storyTitle, storyIndex, storyId);
                 
                 if (storyData) {
                     // Add click handler
@@ -1143,13 +1144,23 @@ export function init(_root) {
          * @param {string} storyIndex - Story index
          * @returns {Object|null} - Story data object or null if not found
          */
-        function findStoryData(storiesData, epicName, storyTitle, storyIndex) {
+        function findStoryData(storiesData, epicName, storyTitle, storyIndex, storyId) {
             return storiesData.find(story => {
-                // Match by epic name and story title (most reliable)
+                // Primary: match by storyId (unique per file, immune to title formatting)
+                if (storyId && story.storyId && story.storyId === storyId) {
+                    return true;
+                }
+
+                // Match by epic name and story title (builder view)
                 if (story.epicName === epicName && story.title === storyTitle) {
                     return true;
                 }
-                
+
+                // In cross-team search, data-epic-name is the team name (one epic per team)
+                if (story.teamName === epicName && story.title === storyTitle) {
+                    return true;
+                }
+
                 // Fallback: match by title only for unique titles
                 if (story.title === storyTitle) {
                     const titleMatches = storiesData.filter(s => s.title === storyTitle);


### PR DESCRIPTION
…earch (#59)

- Story details modal now has Edit/Save/Discard flow: opens read-only, Edit button enables fields, Save Changes writes back to disk via FileSystem API, Discard prompts if changes were made
- Fix findStoryData to match by storyId (primary), team name (cross-team view), or epic name + title (fallback) — previously stories with special characters or duplicate titles across teams were unclickable
- Fix roadmap-generator to use raw values in data-story-title and data-epic-name attributes instead of formatText() output, so lookup always matches the raw story data