### PR TITLE
Fix force-text-below toggle broken by ES module refactoring

### DIFF
--- a/web/roadmap-generator.js
+++ b/web/roadmap-generator.js
@@ -1538,18 +1538,18 @@ export class RoadmapGenerator {
                 // Global force: when enabled, always position below and align with story start
                 // Check localStorage, main form temporary variable, and search results temporary variable
                 const forceBelowFromConfig = (typeof getConfigUtility === 'function' && getConfigUtility().shouldForceTextBelow());
-                const forceBelowFromTemp = (typeof tempForceTextBelow !== 'undefined' && tempForceTextBelow);
-                const forceBelowFromSearch = (typeof searchTempForceTextBelow !== 'undefined' && searchTempForceTextBelow);
+                const forceBelowFromTemp = !!(window.tempForceTextBelow);
+                const forceBelowFromSearch = !!(window.searchTempForceTextBelow);
                 const forceBelowGlobal = forceBelowFromConfig || forceBelowFromTemp || forceBelowFromSearch;
                 if (forceBelowGlobal) {
                     shouldPositionBelowFinal = true;
                 }
-                
+
                 if (shouldPositionBelowFinal) {
                     // Position below story, align start with story start when forced; otherwise small indent
                     const forceBelowFromConfig = (typeof getConfigUtility === 'function' && getConfigUtility().shouldForceTextBelow());
-                    const forceBelowFromTemp = (typeof tempForceTextBelow !== 'undefined' && tempForceTextBelow);
-                    const forceBelowFromSearch = (typeof searchTempForceTextBelow !== 'undefined' && searchTempForceTextBelow);
+                    const forceBelowFromTemp = !!(window.tempForceTextBelow);
+                    const forceBelowFromSearch = !!(window.searchTempForceTextBelow);
                     const forceBelowGlobal = forceBelowFromConfig || forceBelowFromTemp || forceBelowFromSearch;
                     changeStartGrid = forceBelowGlobal ? storyStartGrid : (storyStartGrid + 1);
                     changeEndGrid = changeStartGrid + textBoxWidth;

--- a/web/views/builder/builder.js
+++ b/web/views/builder/builder.js
@@ -902,12 +902,18 @@ export function init(_root) {
         function handleForceTextBelowToggle() {
             const toggle = document.getElementById('force-text-below-toggle');
             if (toggle) {
-                // Use temporary variable instead of saving to localStorage
                 tempForceTextBelow = toggle.checked;
-                // Regenerate the preview to apply placement
+                window.tempForceTextBelow = tempForceTextBelow;
                 generatePreview();
             }
         }
+
+        // Event delegation so the handler works regardless of element lifecycle
+        document.addEventListener('change', (e) => {
+            if (e.target && e.target.id === 'force-text-below-toggle') {
+                handleForceTextBelowToggle();
+            }
+        });
 
         // (originalStoryOrders, storeOriginalStoryOrder, reorderStoriesInUI,
         // restoreOriginalStoryOrder, showSortingNotification moved to ./sorting.js)
@@ -3123,6 +3129,7 @@ export function init(_root) {
                 if (textBelowToggle) textBelowToggle.checked = false;
                 // Reset temporary force text below variable
                 tempForceTextBelow = false;
+                window.tempForceTextBelow = false;
                 // Persist cleared state
                 getConfigUtility().setSortStories(false);
                 getConfigUtility().setSortByStart(false);

--- a/web/views/imo-search/imo-search.js
+++ b/web/views/imo-search/imo-search.js
@@ -1295,11 +1295,19 @@ export function init(_root) {
         /**
          * Handle force text below toggle in search results
          */
+        // Event delegation for the dynamically-rendered search toggle
+        document.addEventListener('change', (e) => {
+            if (e.target && e.target.id === 'search-force-text-below-toggle') {
+                handleSearchForceTextBelowToggle();
+            }
+        });
+
         function handleSearchForceTextBelowToggle() {
             const toggle = document.getElementById('search-force-text-below-toggle');
             if (toggle) {
                 // Use temporary variable instead of saving to localStorage
                 searchTempForceTextBelow = toggle.checked;
+                window.searchTempForceTextBelow = searchTempForceTextBelow;
                 // Regenerate the search results to apply placement
                 const teamInfoMap = buildTeamInfoMap(lastRoadmapFiles);
                 displaySearchResults(currentResults, lastSearchQuery, null, teamInfoMap);
@@ -1350,9 +1358,10 @@ export function init(_root) {
                     if (searchToggle) {
                         searchToggle.checked = false;
                         searchTempForceTextBelow = false;
+                        window.searchTempForceTextBelow = false;
                     }
                 }
-                
+
                 // Update lastSearchQuery for next comparison
                 lastSearchQuery = searchQuery;
                 


### PR DESCRIPTION
Before the module refactoring (d7db542), tempForceTextBelow was a true global in a <script> tag. After conversion to ES modules it became a closure-scoped variable, invisible to roadmap-generator.js which checked it via bare typeof lookup.

Fix by mirroring the value onto window.tempForceTextBelow (and window.searchTempForceTextBelow for the search view) on every change, reading it explicitly via window.X in roadmap-generator.js, and wiring the toggle handlers via event delegation so they fire regardless of where window.handleForceTextBelowToggle is set in the init lifecycle.