### PR TITLE
Fix IMO<suffix> expression token to use startsWith

### DIFF
--- a/web/views/imo-search/imo-search.js
+++ b/web/views/imo-search/imo-search.js
@@ -1974,7 +1974,7 @@ export function init(_root) {
             // suffix regex requires at least one non-operator character.
             processedExpr = processedExpr.replace(/\bIMO([^\s!&|()"]+)/gi, (match, value) => {
                 const imo = (story.imo || '').toLowerCase();
-                return imo.includes(value.toLowerCase()) ? 'TRUE' : 'FALSE';
+                return imo.startsWith(('imo' + value).toLowerCase()) ? 'TRUE' : 'FALSE';
             });
 
             // PRIORITY="value" - matches priority value (exact, case-insensitive)


### PR DESCRIPTION
## Summary
- `IMO1`, `IMO2` etc. in the advanced expression were checking `imo.includes('1')` — too broad, matched any story whose IMO field contained that digit anywhere
- Now checks `imo.startsWith('imo1')` so `IMO1` only returns stories whose IMO field begins with "IMO1"

## Test plan
- [ ] Type `IMO1` in advanced expression — only stories starting with "IMO1", not "RR1" or "IMP 001"
- [ ] Type `IMO2 && Q2` — only IMO2 stories ending in Q2

🤖 Generated with [Claude Code](https://claude.com/claude-code)