### PR TITLE
Delay hover zoom/dim by 0.4s to prevent triggering while scrolling

### DIFF
--- a/web/roadmap-styles.css
+++ b/web/roadmap-styles.css
@@ -342,32 +342,38 @@ body {
 .ktlo-story.story-zoom-large:hover {
     transform: translateX(-4px) scale(1.20);
     z-index: 200;
+    transition: transform 0.2s ease 0.4s;
 }
 
 .ktlo-story.story-zoom-medium:hover {
     transform: translateX(-4px) scale(1.15);
     z-index: 200;
+    transition: transform 0.2s ease 0.4s;
 }
 
 .ktlo-story.story-zoom-small:hover {
     transform: translateX(-4px) scale(1.05);
     z-index: 200;
+    transition: transform 0.2s ease 0.4s;
 }
 
 /* Story States - Graduated Zoom Levels */
 .story-zoom-large:hover {
     transform: scale(1.20);
     z-index: 200;
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-zoom-medium:hover {
     transform: scale(1.15);
     z-index: 200;
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-zoom-small:hover {
     transform: scale(1.05);
     z-index: 200;
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-positioned-january {
@@ -380,26 +386,32 @@ body {
 
 .story-positioned-january.story-zoom-large:hover {
     transform: translateX(-4px) scale(1.20);
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-positioned-october.story-zoom-large:hover {
     transform: translateX(1px) scale(1.20);
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-positioned-january.story-zoom-medium:hover {
     transform: translateX(-4px) scale(1.15);
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-positioned-october.story-zoom-medium:hover {
     transform: translateX(1px) scale(1.15);
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-positioned-january.story-zoom-small:hover {
     transform: translateX(-4px) scale(1.05);
+    transition: transform 0.2s ease 0.4s;
 }
 
 .story-positioned-october.story-zoom-small:hover {
     transform: translateX(1px) scale(1.05);
+    transition: transform 0.2s ease 0.4s;
 }
 
 /* Focus dim effect: when any story bar or textbox is hovered (or synchronized
@@ -412,7 +424,7 @@ body {
 .roadmap-container:has(.story-item:hover, .ktlo-story:hover, .story-hover, .textbox-hover, .roadmap-text:hover) .monthly-box-content,
 .roadmap-container:has(.story-item:hover, .ktlo-story:hover, .story-hover, .textbox-hover, .roadmap-text:hover) .roadmap-text:not(.textbox-hover):not(:hover) {
     opacity: 0.35;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease 0.4s;
 }
 
 /* Keep the story bar in focus when its companion side status text box is
@@ -804,6 +816,7 @@ html[data-status-style="side"]
     transform: scale(1.3);
     z-index: 300;
     box-shadow: var(--rm-hover-shadow);
+    transition: transform 0.2s ease 0.4s, box-shadow 0.2s ease 0.4s;
 }
 
 .roadmap-text:hover * {


### PR DESCRIPTION
## Summary
- Adds a 0.4s `transition-delay` to all story and text box zoom/dim hover effects
- Prevents the zoom and dimming from triggering while the mouse is passing over items during scrolling
- The delay only applies when entering hover — mouse-out snaps back instantly (no delay)

## Test plan
- [ ] Scroll through the roadmap and confirm stories no longer zoom/dim as the mouse passes over them
- [ ] Hover and hold on a story — confirm zoom and dim activate after ~0.4s
- [ ] Move mouse off a story — confirm immediate return to normal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)